### PR TITLE
Update 20230531_REQ_convPprCovadis2Cnig.sql

### DIFF
--- a/ressources/traduction/Traduction-SQL-Bourg-dOisan/20230531_REQ_convPprCovadis2Cnig.sql
+++ b/ressources/traduction/Traduction-SQL-Bourg-dOisan/20230531_REQ_convPprCovadis2Cnig.sql
@@ -1,24 +1,21 @@
 /*
-RequÍtes : essais de convertion de PPR COVADIS en CNIG
+Requ√™tes : essais de conversion de PPRN COVADIS en CNIG
 Auteur : Stanislas Besson - DDT38/SAET/SIG-OBS
-Date : crÈÈe le 31 mai 2023
+Date : cr√©√©e le 31 mai 2023
 */
 
 /*
-PPR testÈ : PPRN - Le Bourg d'Oisans
-GASPAR : 38DDT20200002
-Date appro : 23/12/2022
+PPRN test√©s : base d√©partementale des PPRT approuv√©s de l'Is√®re
 Zonage : oui
-AlÈa : Oui
+Al√©a : Oui
 Enjeux : Non
 */
-
 
 -- -------------------
 -- TABLE PROCEDURE_PPR
 -- -------------------
 
--- CrÈation table
+-- Cr√©ation table
 
 DROP TABLE IF EXISTS s_cnig_risques_tmp.procedure_ppr ;
 
@@ -30,15 +27,15 @@ lib_type_procedure varchar(200),
 CONSTRAINT procedure_ppr_pk PRIMARY KEY (code_procedure)
 );
 
--- Insertion des donnÈes depuis les tables COVADIS
+-- Insertion des donn√©es depuis les tables COVADIS
 
 INSERT INTO s_cnig_risques_tmp.procedure_ppr
 (code_procedure,libelle_procedure,code_type_procedure)
-SELECT id_gaspar, nom, CASE WHEN coderisque = '9999999' THEN 'PPRN-Multi' ELSE 'PPRN-I' END -- case when spÈcifique standardisation PPRN IsËre
+SELECT id_gaspar, nom, CASE WHEN coderisque = '9999999' THEN 'PPRN-Multi' ELSE 'PPRN-I' END -- case when sp√©cifique standardisation PPRN Is√®re
 FROM c_risque__n_zonages_risque_naturel.n_document_pprn_s_038
 ;
 
--- Mise ‡ jour du libellÈ en fonction du code PROCEDURE
+-- Mise √† jour du libell√© en fonction du code PROCEDURE
 
 UPDATE s_cnig_risques_tmp.procedure_ppr AS a SET
 lib_type_procedure = libelle
@@ -49,7 +46,7 @@ WHERE a.code_type_procedure = b.code ;
 -- TABLE REF_INTERNET_PPR
 -- ----------------------
 
--- CrÈation table
+-- Cr√©ation table
 
 DROP TABLE IF EXISTS s_cnig_risques_tmp.ref_internet_ppr;
 
@@ -65,11 +62,11 @@ REFERENCES s_cnig_risques_tmp.procedure_ppr (code_procedure)
 MATCH FULL ON UPDATE CASCADE ON DELETE CASCADE
 );
 
--- Insertion des donnÈes depuis les tables COVADIS
+-- Insertion des donn√©es depuis les tables COVADIS
 
 INSERT INTO s_cnig_risques_tmp.ref_internet_ppr
 (code_procedure, adresse, nom_ressource, description, type_reference)
-SELECT id_gaspar,site_web, (regexp_split_to_array(site_web,'/'))[8],'les PPRN du dÈpartement de l''IsËre','PiËces Ècrites des documents en vigueur'
+SELECT id_gaspar,site_web, (regexp_split_to_array(site_web,'/'))[8],'les PPRN du d√©partement de l''Is√®re','Pi√®ces √©crites des documents en vigueur'
 FROM c_risque__n_zonages_risque_naturel.n_document_pprn_s_038
 ;
 
@@ -78,7 +75,7 @@ FROM c_risque__n_zonages_risque_naturel.n_document_pprn_s_038
 -- TABLE PERIMETRE_PPR
 -- -------------------
 
--- CrÈation table
+-- Cr√©ation table
 
 DROP TABLE IF EXISTS s_cnig_risques_tmp.perimetre_ppr ;
 
@@ -97,7 +94,7 @@ CREATE INDEX perimetre_ppr_sdx
 ON s_cnig_risques_tmp.perimetre_ppr USING gist (geom)
 ;
 
--- Insertion des donnÈes depuis les tables COVADIS
+-- Insertion des donn√©es depuis les tables COVADIS
 
 INSERT INTO s_cnig_risques_tmp.perimetre_ppr
 (code_procedure,etat_procedure,date_perimetre,geom)
@@ -118,7 +115,7 @@ FROM c_risque__n_zonages_risque_naturel.n_document_pprn_s_038
 -- TABLE ALEA_PPR
 -- --------------
 
--- CrÈation table
+-- Cr√©ation table
 
 DROP TABLE IF EXISTS s_cnig_risques_tmp.alea_ppr ;
 
@@ -140,7 +137,7 @@ CREATE INDEX alea_ppr_sdx
 ON s_cnig_risques_tmp.alea_ppr USING gist (geom)
 ;
 
--- Insertion des donnÈes depuis les tables COVADIS
+-- Insertion des donn√©es depuis les tables COVADIS
 
 INSERT INTO s_cnig_risques_tmp.alea_ppr
 (id_zone_alea, code_procedure, code_type_alea, description, geom)
@@ -148,7 +145,7 @@ SELECT id_zone, id_gaspar, left(coderisque,3), descript, geom
 FROM c_risque__n_zonages_risque_naturel.n_zone_alea_pprn_s_038
 ;
 
--- Mise ‡ jour des libellÈs
+-- Mise √† jour des libell√©s
 
 UPDATE s_cnig_risques_tmp.alea_ppr SET
 lib_type_alea = libelle
@@ -160,7 +157,7 @@ WHERE code_type_alea = code
 -- TABLE ZONAGE_REG_PPR
 -- --------------------
 
--- CrÈation table
+-- Cr√©ation table
 
 DROP TABLE IF EXISTS s_cnig_risques_tmp.zonage_reg_ppr ;
 
@@ -182,7 +179,7 @@ CREATE INDEX zonage_reg_ppr_sdx
 ON s_cnig_risques_tmp.zonage_reg_ppr USING gist (geom)
 ;
 
--- Insertion des donnÈes depuis les tables COVADIS
+-- Insertion des donn√©es depuis les tables COVADIS
 
 INSERT INTO  s_cnig_risques_tmp.zonage_reg_ppr (
 id_zone_reg, code_procedure, code_zone_reg, lib_zone_reg, code_type_reg, geom)
@@ -190,7 +187,7 @@ SELECT id_zone, id_gaspar, codezone, nom, typereg,geom
 FROM c_risque__n_zonages_risque_naturel.n_zone_reg_pprn_s_038
 ;
 
--- Mise ‡ jour des libellÈs
+-- Mise √† jour des libell√©s
 
 UPDATE s_cnig_risques_tmp.zonage_reg_ppr SET
 lib_zone_reg = libelle


### PR DESCRIPTION
Mise à jour des commentaires.
Le script porte uniquement sur la conversion de la base départementale postgreSQL des PPRN approuvés de l'Isère.
Il implique que l'ensemble des PPRN à convertir soient déjà agrégé.
Le script porte sur la conversion des tables suivantes :
- N_DOCUMENT_PPRN_S_038 : liste des PPRN approuvés en Isère
- N_ZONE_REG_PPRN_S_038 : ensemble des zones réglementaires des PPRN approuvés en Isère
- N_ZONE_ALEA_PPRN_S_038 : ensemble des zones d'aléas numérisésdes PPRN approuvés en Isère 

Le lien avec la table N_DOCUMENT_PPRN_S_038 se fait par le système de clé primaire / clé étrangère sur l'attribut ID_GASPAR, qui est l'identifiant unique du PPR dans la base GASPAR